### PR TITLE
Drilldown to only existing data

### DIFF
--- a/chart/pie.js
+++ b/chart/pie.js
@@ -37,11 +37,12 @@ export function createDrilldownDataStructure(rows, seriesName) {
     const selector = row.selector
 
 
-    const drillDownData = row.drillDown.map(dr => {
-      const drillDownValue = parseNumber(dr.value)
-      return [ dr.group, drillDownValue, ]
-    })
-    drillDownSeries.push({ name: selector, id: selector, data: drillDownData, })
+    const drillDownData = [];
+    for (let j = 0; j < row.drillDown.length; j++) {
+      const drillDownValue = parseNumber(row.drillDown[j].value)
+      if (drillDownValue == 0) continue;
+      drillDownData.push([row.drillDown[j].group, drillDownValue, ])
+    }
 
     let seriesValue = parseNumber(row.value)
 


### PR DESCRIPTION
Suppose that there are three categories, say Coffee, Cocktail, Juice.
Let there be also subcategories, say Espresso, Americano, Martini, ....
Espresso only appears on Coffee, but if you drilldown to cocktail you will see the subcategory Espresso with 0 value.
This PR makes it clear to drilldown to only existing datas.